### PR TITLE
Added a return value to the receive method with the packet lenght

### DIFF
--- a/Inc/LoRa.h
+++ b/Inc/LoRa.h
@@ -122,7 +122,7 @@ void LoRa_setOCP(LoRa* _LoRa, uint8_t current);
 void LoRa_setTOMsb_setCRCon(LoRa* _LoRa);
 uint8_t LoRa_transmit(LoRa* _LoRa, uint8_t* data, uint8_t length, uint16_t timeout);
 void LoRa_startReceiving(LoRa* _LoRa);
-void LoRa_receive(LoRa* _LoRa, uint8_t* data, uint8_t length);
+uint8_t LoRa_receive(LoRa* _LoRa, uint8_t* data, uint8_t length);
 void LoRa_receive_IT(LoRa* _LoRa, uint8_t* data, uint8_t length);
 int LoRa_getRSSI(LoRa* _LoRa);
 

--- a/Src/LoRa.c
+++ b/Src/LoRa.c
@@ -416,12 +416,12 @@ void LoRa_startReceiving(LoRa* _LoRa){
 			uint8_t  data			--> A pointer to the array that you want to write bytes in it
 			uint8_t	 length   --> Determines how many bytes you want to read
 
-		returns     : Nothing
+		returns     : The number of bytes received
 \* ----------------------------------------------------------------------------- */
-void LoRa_receive(LoRa* _LoRa, uint8_t* data, uint8_t length){
+uint8_t LoRa_receive(LoRa* _LoRa, uint8_t* data, uint8_t length){
 	uint8_t read;
 	uint8_t number_of_bytes;
-	uint8_t min;
+	uint8_t min = 0;
 
 	for(int i=0; i<length; i++)
 		data[i]=0;
@@ -438,6 +438,7 @@ void LoRa_receive(LoRa* _LoRa, uint8_t* data, uint8_t length){
 			data[i] = LoRa_read(_LoRa, RegFiFo);
 	}
 	LoRa_gotoMode(_LoRa, RXCONTIN_MODE);
+    return min;
 }
 
 /* ----------------------------------------------------------------------------- *\


### PR DESCRIPTION
Hi,
I added the packet lenght as the returned value for the receive method.
I think this is not the best way but it was quick and dirty and I needed it for my project.

The best solution could be to pass the packet lenght as a pointer instead of as a value and change it if the lenght was different than expected. This way a status/error value could be returned like "lora_ok" if the lenght was the same, "lora_different_lenght" if the lenght was different than the given one and "lora_nothing_received" if the buffer was empty.

This solution is not compatible with older code though so I'm just opening a request with the first method which should be compatible straight forward.

Let me know what you think.