### PR TITLE
To fix AutoLDO for SF11

### DIFF
--- a/LoRa/LoRa.c
+++ b/LoRa/LoRa.c
@@ -177,7 +177,7 @@ void LoRa_setLowDaraRateOptimization(LoRa* _LoRa, uint8_t value){
 void LoRa_setAutoLDO(LoRa* _LoRa){
 	double BW[] = {7.8, 10.4, 15.6, 20.8, 31.25, 41.7, 62.5, 125.0, 250.0, 500.0};
 	
-	LoRa_setLowDaraRateOptimization(_LoRa, ((1 << _LoRa->spredingFactor) / ((double)BW[_LoRa->bandWidth])) >= 16.0);
+	LoRa_setLowDaraRateOptimization(_LoRa, (long)((1 << _LoRa->spredingFactor) / ((double)BW[_LoRa->bandWidth])) > 16.0);
 }
 
 /* ----------------------------------------------------------------------------- *\


### PR DESCRIPTION
The patch is to fix Auto LDO for SF11.
SF7-11 should have LDO off and SF12 should have LDO on.

Tested sending and receiving OK for SF7-12 between STM32L0+this library and ESP32+Arduino-LoRa.